### PR TITLE
Add persistence, auth and frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Example environment variables
 RABBITMQ_URL=amqp://localhost
+API_TOKEN=secret

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Messenger Project
 
-This repository contains a minimal skeleton for a messenger application built with **Nest.js**, **GraphQL** and **RabbitMQ**.
+This project demonstrates a small messenger built with **Nest.js**, **GraphQL** and **RabbitMQ**. Messages are now persisted to a JSON file and protected by a very simple token based authentication. A lightweight Vue.js front-end is included in the `frontend/` directory.
 
 ## Features
 
@@ -8,6 +8,9 @@ This repository contains a minimal skeleton for a messenger application built wi
 - List of users *(placeholder)*
 - List and details of conversations *(placeholder)*
 - Sending messages through RabbitMQ
+- File based message persistence
+- Token authentication
+- Minimal Vue.js client
 
 ## Stack
 
@@ -57,11 +60,17 @@ npm run start:dev --prefix backend
 npm run start:dev --prefix worker
 ```
 
+7. Open the front-end at `http://localhost:3000/index.html`.
+
 The GraphQL playground is available at `http://localhost:3000/graphql`.
 
 ## Testing
 
-- Unit and integration tests are not yet implemented.
+Unit tests are located in `backend/test/` and can be executed with:
+
+```bash
+npm test
+```
 
 ### Example GraphQL queries
 
@@ -83,5 +92,4 @@ query {
 }
 ```
 
-This skeleton is a starting point for the project. Extend it by adding authentication, persistence, real-time subscriptions and a frontend client.
-
+This skeleton can be extended with real databases, authentication strategies or real-time subscriptions.

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/main.js",
     "start:dev": "ts-node src/main.ts",
     "build": "tsc",
-    "test": "echo \"No tests yet\""
+    "test": "node --test --loader ts-node/esm"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { MessageModule } from './message/message.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
     GraphQLModule.forRoot({
       autoSchemaFile: true,
     }),
+    AuthModule,
     MessageModule,
   ],
 })

--- a/backend/src/auth/auth.guard.ts
+++ b/backend/src/auth/auth.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const ctx = GqlExecutionContext.create(context);
+    const req = ctx.getContext().req;
+    const header = req.headers['authorization'] || '';
+    const token = header.replace('Bearer ', '');
+    return this.authService.validateToken(token);
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Module({
+  providers: [AuthService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { config } from 'dotenv';
+
+config();
+
+@Injectable()
+export class AuthService {
+  private readonly token = process.env.API_TOKEN || 'secret';
+
+  validateToken(token: string): boolean {
+    return token === this.token;
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,11 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { join } from 'path';
+import * as express from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.use('/', express.static(join(__dirname, '../frontend')));
   await app.listen(3000);
   console.log('API running on http://localhost:3000/graphql');
 }

--- a/backend/src/message/message.module.ts
+++ b/backend/src/message/message.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { MessageResolver } from './message.resolver';
 import { MessageService } from './message.service';
+import { MessageRepository } from './message.repository';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  providers: [MessageResolver, MessageService],
+  imports: [AuthModule],
+  providers: [MessageResolver, MessageService, MessageRepository],
 })
 export class MessageModule {}

--- a/backend/src/message/message.repository.ts
+++ b/backend/src/message/message.repository.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+@Injectable()
+export class MessageRepository {
+  private readonly file = join(__dirname, '../../messages.json');
+  private messages: { id: number; content: string }[] = [];
+
+  async load() {
+    try {
+      const data = await fs.readFile(this.file, 'utf-8');
+      this.messages = JSON.parse(data);
+    } catch {
+      this.messages = [];
+    }
+  }
+
+  private async save() {
+    await fs.writeFile(this.file, JSON.stringify(this.messages, null, 2));
+  }
+
+  async create(content: string) {
+    const message = { id: Date.now(), content };
+    this.messages.push(message);
+    await this.save();
+    return message;
+  }
+
+  async findAll() {
+    return this.messages;
+  }
+}

--- a/backend/src/message/message.resolver.ts
+++ b/backend/src/message/message.resolver.ts
@@ -1,18 +1,22 @@
 import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { MessageType } from './message.type';
+import { AuthGuard } from '../auth/auth.guard';
 
 @Resolver(() => MessageType)
 export class MessageResolver {
   constructor(private readonly messageService: MessageService) {}
 
   @Query(() => [MessageType])
-  messages() {
+  @UseGuards(AuthGuard)
+  async messages() {
     return this.messageService.findAll();
   }
 
   @Mutation(() => MessageType)
-  sendMessage(@Args('content') content: string) {
+  @UseGuards(AuthGuard)
+  async sendMessage(@Args('content') content: string) {
     return this.messageService.create(content);
   }
 }

--- a/backend/src/message/message.service.ts
+++ b/backend/src/message/message.service.ts
@@ -1,16 +1,32 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import * as amqp from 'amqplib';
+import { MessageRepository } from './message.repository';
 
 @Injectable()
-export class MessageService {
-  private messages: { id: number; content: string }[] = [];
+export class MessageService implements OnModuleInit {
+  private channel: amqp.Channel | undefined;
+  constructor(private readonly repo: MessageRepository) {}
 
-  create(content: string) {
-    const message = { id: Date.now(), content };
-    this.messages.push(message);
+  async onModuleInit() {
+    await this.repo.load();
+    try {
+      const conn = await amqp.connect(process.env.RABBITMQ_URL || 'amqp://localhost');
+      this.channel = await conn.createChannel();
+      await this.channel.assertQueue('messages');
+      await this.channel.assertQueue('notifications');
+    } catch {}
+  }
+
+  async create(content: string) {
+    const message = await this.repo.create(content);
+    if (this.channel) {
+      this.channel.sendToQueue('messages', Buffer.from(content));
+      this.channel.sendToQueue('notifications', Buffer.from('new message'));
+    }
     return message;
   }
 
-  findAll() {
-    return this.messages;
+  async findAll() {
+    return this.repo.findAll();
   }
 }

--- a/backend/test/message.service.test.js
+++ b/backend/test/message.service.test.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const { MessageService } = require('../src/message/message.service');
+const { MessageRepository } = require('../src/message/message.repository');
+
+class InMemoryRepo extends MessageRepository {
+  constructor() { super(); this.messages = []; }
+  async load() {}
+  async save() {}
+}
+
+test('create and fetch message', async () => {
+  const repo = new InMemoryRepo();
+  const service = new MessageService(repo);
+  await service.onModuleInit();
+  await service.create('hello');
+  const msgs = await service.findAll();
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].content, 'hello');
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Messenger</title>
+  <script src="https://unpkg.com/vue@3"></script>
+</head>
+<body>
+  <div id="app">
+    <h1>Messages</h1>
+    <ul>
+      <li v-for="m in messages" :key="m.id">{{ m.content }}</li>
+    </ul>
+    <input v-model="text" placeholder="Type message"/>
+    <button @click="send">Send</button>
+  </div>
+  <script>
+    const token = 'secret';
+    const app = Vue.createApp({
+      data() {
+        return { messages: [], text: '' };
+      },
+      mounted() { this.fetchMessages(); },
+      methods: {
+        async fetchMessages() {
+          const res = await fetch('/graphql', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json','Authorization':'Bearer '+token},
+            body: JSON.stringify({ query: '{ messages { id content } }' })
+          });
+          const json = await res.json();
+          this.messages = json.data.messages;
+        },
+        async send() {
+          await fetch('/graphql', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json','Authorization':'Bearer '+token},
+            body: JSON.stringify({ query: 'mutation($c:String!){ sendMessage(content:$c){ id content } }', variables:{c:this.text} })
+          });
+          this.text='';
+          this.fetchMessages();
+        }
+      }
+    });
+    app.mount('#app');
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "start:backend": "npm run start:dev --prefix backend",
     "start:worker": "npm run start:dev --prefix worker",
-    "test": "echo \"No tests yet\""
+    "test": "npm run test --prefix backend && npm run test --prefix worker"
   }
 }

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,7 +6,7 @@
     "start": "node dist/main.js",
     "start:dev": "ts-node src/main.ts",
     "build": "tsc",
-    "test": "echo \"No tests yet\""
+    "test": "node --test"
   },
   "dependencies": {
     "amqplib": "^0.10.3",

--- a/worker/src/main.ts
+++ b/worker/src/main.ts
@@ -4,12 +4,19 @@ async function bootstrap() {
   const connection = await amqp.connect('amqp://localhost');
   const channel = await connection.createChannel();
   await channel.assertQueue('messages');
+  await channel.assertQueue('notifications');
 
-  console.log('Worker listening for messages...');
+  console.log('Worker listening for messages and notifications...');
   channel.consume('messages', msg => {
     if (msg) {
-      const content = msg.content.toString();
-      console.log('Received:', content);
+      console.log('Message:', msg.content.toString());
+      channel.ack(msg);
+    }
+  });
+
+  channel.consume('notifications', msg => {
+    if (msg) {
+      console.log('Notification:', msg.content.toString());
       channel.ack(msg);
     }
   });


### PR DESCRIPTION
## Summary
- persist messages to JSON
- add token-based authentication
- serve a minimal Vue frontend
- extend worker to handle notifications
- provide example env vars and a simple unit test

## Testing
- `npm test` *(fails: Cannot find package 'ts-node' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68551d69ac948325a948a9f42af587a5